### PR TITLE
changed terminate to end and modify to change close #35

### DIFF
--- a/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
+++ b/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
@@ -192,8 +192,8 @@ fields:
   - no label: order_type
     datatype: radio
     choices:
-      - terminate this Abuse Prevention Order: terminate 
-      - modify this Abuse Prevention Order: modify
+      - End this Abuse Prevention Order: terminate 
+      - Change this Abuse Prevention Order: modify
   - What do you want to change about this order?: what_to_modify
     input type: area
     show if:
@@ -202,11 +202,11 @@ fields:
 ---
 template: translate_word_modify
 content: |
-  modify
+  change
 ---
 template: translate_word_terminate
 content: |
-  terminate
+  end
 ---
 id: explanation of future orders
 question: |
@@ -382,19 +382,19 @@ review:
   - Edit: order_type
     button: |
       % if order_type == "modify":
-        You said you need to **modify** your prevention order.
+        You said you need to **change** your prevention order.
         
         What to change about your prevention order:[BR]
         ${ what_to_modify }
       % else:
-        You said you need to **terminate** your prevention order.
+        You said you need to **end** your prevention order.
       % endif
   - Edit: reason
     button: |
       % if order_type == "modify":
-        Why you need to **modify** your prevention order:[BR]
+        Why you need to **change** your prevention order:[BR]
       % else:
-        Why you need to **terminate** your prevention order:[BR]
+        Why you need to **end** your prevention order:[BR]
       % endif
       ${ reason }
   - Edit: courts[0]


### PR DESCRIPTION
I changed all instances of the words terminate and modify. However, I didn't change the title of the interview or the title for the id: motion to modify intro. For example, the title of the interview is "Ask the court for a Plaintiff Motion to Modify or terminate an Abuse Prevention Order - 209A: Mass Access Project" and I didn't change these instances of modify and terminate.

Tests:
Go through the interview and make sure there are no instances of the words modify or terminate