### PR TITLE
Added to character limits for descriptions close #41

### DIFF
--- a/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
+++ b/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
@@ -197,6 +197,9 @@ fields:
       - End this Abuse Prevention Order: terminate 
       - Change this Abuse Prevention Order: modify
   - note: You can type a maximum of 540 characters
+    show if:
+      variable: order_type
+      is: modify
   - What do you want to change about this order?: what_to_modify
     input type: area
     maxlength: 540
@@ -246,6 +249,7 @@ fields:
   - no label: reason
     input type: area
     maxlength: ${1089 - len(what_to_modify)}
+  - note: You can type a maximum of ${1089 - len(what_to_modify)} characters
 ---
 sets:
   - courts[0]

--- a/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
+++ b/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
@@ -236,13 +236,6 @@ fields:
       minlength: |
         You cannot continue unless you confirm you understand.
 ---
-id: modification description
-question: |
-  What do you want to change?
-fields:
-  - no label: what_to_modify
-    input type: area
----
 id: reason for request
 question: |
   Why do you want to ${ translate_word_modify if order_type == "modify" else translate_word_terminate }

--- a/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
+++ b/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
@@ -194,12 +194,17 @@ fields:
     choices:
       - terminate this Abuse Prevention Order: terminate 
       - modify this Abuse Prevention Order: modify
+  - note: You can type a maximum of 540 characters
   - What do you want to change about this order?: what_to_modify
     input type: area
-    maxlength: 2
+    maxlength: 540
     show if:
       variable: order_type
       is: modify
+---
+code: |
+  what_to_modify = ""
+  #This is to ensure that the length of what_to_modify can be used in another calcuation
 ---
 template: translate_word_modify
 content: |
@@ -245,7 +250,7 @@ question: |
 fields:
   - no label: reason
     input type: area
-    maxlength: 2
+    maxlength: ${1089 - len(what_to_modify)}
 ---
 sets:
   - courts[0]

--- a/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
+++ b/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
@@ -379,7 +379,9 @@ review:
     button: |
       Defendant:
       ${ other_parties[0] }
-  - Edit: order_type
+  - Edit: 
+      - order_type
+      - reason
     button: |
       % if order_type == "modify":
         You said you need to **modify** your prevention order.

--- a/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
+++ b/docassemble/209aPlaintiffMotionToModify/data/questions/209a_plaintiff_s_motion_to_modify.yml
@@ -196,6 +196,7 @@ fields:
       - modify this Abuse Prevention Order: modify
   - What do you want to change about this order?: what_to_modify
     input type: area
+    maxlength: 2
     show if:
       variable: order_type
       is: modify
@@ -244,6 +245,7 @@ question: |
 fields:
   - no label: reason
     input type: area
+    maxlength: 2
 ---
 sets:
   - courts[0]


### PR DESCRIPTION
I added character limits to the questions with ids: reason for request and type of request. I put the character limit at 2 since it makes it easy to test and I am not sure what it should eventually be.

Tests:
- Put more than two characters in the text areas with character limits
- Put two characters or less in the text areas with character limits and finish the form

Closes #41